### PR TITLE
[test] 자코코 도입 및 MemberController 통합 테스트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ jacocoTestReport {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, excludes: [
-                            // 측정 안하고 싶은 패턴
+                            '**/dto/**',
+                            '**/domain/**'
                     ])
                 })
         )
@@ -68,6 +69,8 @@ jacocoTestCoverageVerification {
             }
 
             excludes = [
+                    '**/dto/**',
+                    '**/domain/**'
             ]
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ dependencies {
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     // Spring Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,75 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.3'
     id 'io.spring.dependency-management' version '1.1.4'
+    id 'jacoco'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy 'jacocoTestReport' // 추가: test -> jacocoTestReport
+}
+
+jacoco {
+    toolVersion = '0.8.8'
+}
+
+jacocoTestReport {
+    reports{
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(true)
+        html.destination file("$buildDir/reports/jacoco/index.html")
+        xml.destination file("$buildDir/reports/jacoco/index.xml")
+        csv.destination file("$buildDir/reports/jacoco/index.csv")
+    }
+
+    def Qdomains = []
+    for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+        Qdomains.add(qPattern + '*')
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            // 측정 안하고 싶은 패턴
+                    ])
+                })
+        )
+    }
+    // 추가: jacocoTestReport -> jacocoTestCoverageVerification
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    def Qdomains = []
+    for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+        Qdomains.add(qPattern + '*')
+    }
+
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            // 라인 커버리지 설정
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                /*minimum = 0.70*/
+            }
+
+            // 브랜치 커버리지 설정
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                /*minimum = 0.70*/
+            }
+
+            excludes = [
+            ]
+        }
+    }
 }
 
 group = 'com.example'
@@ -71,8 +140,4 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
 }

--- a/src/test/java/com/example/bolmalre/member/web/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/bolmalre/member/web/controller/MemberControllerTest.java
@@ -10,6 +10,7 @@ import com.example.bolmalre.member.service.MemberServiceImpl;
 import com.example.bolmalre.member.service.port.LocalDateHolder;
 import com.example.bolmalre.member.service.port.MemberProfileImageRepository;
 import com.example.bolmalre.member.service.port.MemberRepository;
+import com.example.bolmalre.member.web.dto.MemberFindUsernameDTO;
 import com.example.bolmalre.member.web.dto.MemberJoinDTO;
 import com.example.bolmalre.member.web.dto.MemberPasswordValidDTO;
 import com.example.bolmalre.member.web.dto.MemberUpdateDTO;
@@ -821,7 +822,7 @@ class MemberControllerTest {
 
 
     @Test
-    @DisplayName("")
+    @DisplayName("비밀번호 패턴에 맞지 않는 비밀번호로 업데이트를 시도하면 정해진 예외를 반환한다")
     @WithMockUser(username = "test12", roles = "USER")
     public void validPassword_fail_password() throws Exception {
         //given
@@ -839,5 +840,56 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.code").value("COMMON400"))
                 .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
                 .andExpect(jsonPath("$.result.validPassword").value("비밀번호는 8~12자의 영문, 숫자, 특수문자를 포함해야 합니다"));
+    }
+
+
+    @Test
+    @DisplayName("getUsername을 이용해서 아이디를 조회 할 수 있다")
+    public void getUsername_success() throws Exception {
+        //given
+
+        // when & then
+        // GET 메서드는 바디로 요청을 받는게 안된다는걸 깜빡하고 삽질을 ....
+        mockMvc.perform(get("/members/usernames")
+                        .param("name", "test")
+                        .param("phoneNumber", "010-1234-5678"))
+                .andDo(print())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("COMMON200"))
+                .andExpect(jsonPath("$.message").value("성공입니다."))
+                .andExpect(jsonPath("$.result.username").value("test12"));
+    }
+
+
+    @Test
+    @DisplayName("회원을 찾지 못하면 정해진 예외를 반환한다")
+    public void getUsername_fail() throws Exception {
+        //given
+
+        // when & then
+        mockMvc.perform(get("/members/usernames")
+                        .param("name", "err")
+                        .param("phoneNumber", "010-1234-5678"))
+                .andDo(print())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("MEMBER4004"))
+                .andExpect(jsonPath("$.message").value("회원을 찾을 수 없습니다"));
+    }
+
+
+    @Test
+    @DisplayName("핸드폰 번호가 정해진 패턴과 일치하지 않으면 정해진 예외를 반환한다")
+    public void getUsername_fail_phoneNumber() throws Exception {
+        //given
+
+        // when & then
+        mockMvc.perform(get("/members/usernames")
+                        .param("name", "test")
+                        .param("phoneNumber", "err"))
+                .andDo(print())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON400"))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.result.phoneNumber").value("유효하지 않은 전화번호 형식입니다"));
     }
 }

--- a/src/test/java/com/example/bolmalre/member/web/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/bolmalre/member/web/controller/MemberControllerTest.java
@@ -10,10 +10,7 @@ import com.example.bolmalre.member.service.MemberServiceImpl;
 import com.example.bolmalre.member.service.port.LocalDateHolder;
 import com.example.bolmalre.member.service.port.MemberProfileImageRepository;
 import com.example.bolmalre.member.service.port.MemberRepository;
-import com.example.bolmalre.member.web.dto.MemberFindUsernameDTO;
-import com.example.bolmalre.member.web.dto.MemberJoinDTO;
-import com.example.bolmalre.member.web.dto.MemberPasswordValidDTO;
-import com.example.bolmalre.member.web.dto.MemberUpdateDTO;
+import com.example.bolmalre.member.web.dto.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -891,5 +888,48 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.code").value("COMMON400"))
                 .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
                 .andExpect(jsonPath("$.result.phoneNumber").value("유효하지 않은 전화번호 형식입니다"));
+    }
+
+
+    // 비밀번호 재설정 API에 대한 테스트 코드 역시 리팩터링 후 구현하겠습니다 FIXME
+
+    @Test
+    @DisplayName("validUsernames를 이용하여 Username의 중복검사를 진행 할 수 있다" +
+            "중복이 아니면 true를 반환한다")
+    public void validUsernames_success() throws Exception {
+        //given
+        MemberUsernameValidDTO.MemberUsernameValidRequestDTO request = MemberUsernameValidDTO.MemberUsernameValidRequestDTO.builder()
+                .username("newusername")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/members/valid/usernames")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("COMMON200"))
+                .andExpect(jsonPath("$.message").value("성공입니다."))
+                .andExpect(jsonPath("$.result").value(true));
+    }
+
+
+    @Test
+    @DisplayName("username이 중복되면 false를 반환한다")
+    public void validUsernames_false() throws Exception {
+        //given
+        MemberUsernameValidDTO.MemberUsernameValidRequestDTO request = MemberUsernameValidDTO.MemberUsernameValidRequestDTO.builder()
+                .username("test12")
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/members/valid/usernames")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("COMMON200"))
+                .andExpect(jsonPath("$.message").value("성공입니다."))
+                .andExpect(jsonPath("$.result").value(false));
     }
 }

--- a/src/test/java/com/example/bolmalre/member/web/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/bolmalre/member/web/controller/MemberControllerTest.java
@@ -11,6 +11,7 @@ import com.example.bolmalre.member.service.port.LocalDateHolder;
 import com.example.bolmalre.member.service.port.MemberProfileImageRepository;
 import com.example.bolmalre.member.service.port.MemberRepository;
 import com.example.bolmalre.member.web.dto.MemberJoinDTO;
+import com.example.bolmalre.member.web.dto.MemberPasswordValidDTO;
 import com.example.bolmalre.member.web.dto.MemberUpdateDTO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -772,5 +773,71 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.isSuccess").value(false))
                 .andExpect(jsonPath("$.code").value("MEMBER4004"))
                 .andExpect(jsonPath("$.message").value("회원을 찾을 수 없습니다"));
+    }
+
+
+   /* // BCrypt의 경우 숨어 있는 의존성으로서 추후 인터페이스화 해야합니다. 일단은 호출횟수로서 검증하고 따로 브랜치를 생성하여 수정하겠습니다 FIXME
+    @Test
+    @DisplayName("validPassoword를 이용해서 회원의 비밀번호를 검증 할 수 있다")
+    @WithMockUser(username = "test12", roles = "USER")
+    public void validPassword_success() throws Exception {
+        //given
+        MemberPasswordValidDTO.MemberPasswordValidRequestDTO request = MemberPasswordValidDTO.MemberPasswordValidRequestDTO.builder()
+                .validPassword("Test123!")
+                .build();
+
+        // when & then
+        mockMvc.perform(patch("/members/profiles/passwords/valid")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("COMMON200"))
+                .andExpect(jsonPath("$.message").value("성공입니다."));
+
+        verify(bCryptPasswordEncoder, Mockito.times(1)).matches(anyString(),anyString());
+    }*/
+
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 비밀번호를 검증하면 정해진 예외를 반환한다")
+    @WithMockUser(username = "err", roles = "USER")
+    public void validPassword_fail_memberNotFound() throws Exception {
+        //given
+        MemberPasswordValidDTO.MemberPasswordValidRequestDTO request = MemberPasswordValidDTO.MemberPasswordValidRequestDTO.builder()
+                .validPassword("Test123!")
+                .build();
+
+        // when & then
+        mockMvc.perform(patch("/members/profiles/passwords/valid")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("MEMBER4004"))
+                .andExpect(jsonPath("$.message").value("회원을 찾을 수 없습니다"));
+    }
+
+
+    @Test
+    @DisplayName("")
+    @WithMockUser(username = "test12", roles = "USER")
+    public void validPassword_fail_password() throws Exception {
+        //given
+        MemberPasswordValidDTO.MemberPasswordValidRequestDTO request = MemberPasswordValidDTO.MemberPasswordValidRequestDTO.builder()
+                .validPassword("err")
+                .build();
+
+        // when & then
+        mockMvc.perform(patch("/members/profiles/passwords/valid")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON400"))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
+                .andExpect(jsonPath("$.result.validPassword").value("비밀번호는 8~12자의 영문, 숫자, 특수문자를 포함해야 합니다"));
     }
 }

--- a/src/test/java/com/example/bolmalre/member/web/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/bolmalre/member/web/controller/MemberControllerTest.java
@@ -1,0 +1,209 @@
+package com.example.bolmalre.member.web.controller;
+
+import com.example.bolmalre.member.domain.enums.Gender;
+import com.example.bolmalre.member.web.dto.MemberJoinDTO;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@ActiveProfiles("test")
+class MemberControllerTest {
+
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+
+    @Test
+    @DisplayName("join()을 통해 회원가입을 진행 할 수 있다")
+    void join_success() throws Exception {
+        // given
+        MemberJoinDTO.MemberJoinRequestDTO request = MemberJoinDTO.MemberJoinRequestDTO.builder()
+                .username("test123")
+                .password("Test123!")
+                .name("test")
+                .gender(Gender.FEMALE)
+                .birthDate(LocalDate.of(1, 1, 1))
+                .email("test@naver.com")
+                .phoneNumber("010-1111-1111")
+                .serviceAgreement(true)
+                .privacyAgreement(true)
+                .financialAgreement(true)
+                .advAgreement(true)
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("COMMON200"))
+                .andExpect(jsonPath("$.message").value("성공입니다."))
+                .andExpect(jsonPath("$.result.memberId").exists());
+    }
+
+
+    @Test
+    @DisplayName("비밀번호 패턴에 불일치 할 시, 정해진 예외를 반환한다")
+    void join_fail_password() throws Exception {
+        // given
+        String ERROR_PASSWORD = "error_password";
+
+        MemberJoinDTO.MemberJoinRequestDTO request = MemberJoinDTO.MemberJoinRequestDTO.builder()
+                .username("test123")
+                .password(ERROR_PASSWORD)
+                .name("test")
+                .gender(Gender.FEMALE)
+                .birthDate(LocalDate.of(1, 1, 1))
+                .email("test@naver.com")
+                .phoneNumber("010-1111-1111")
+                .serviceAgreement(true)
+                .privacyAgreement(true)
+                .financialAgreement(true)
+                .advAgreement(true)
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+
+    @Test
+    @DisplayName("username 패턴에 불일치 할 시 정해진 예외를 반환한다")
+    public void join_fail_username() throws Exception {
+        // given
+        String ERROR_USERNAME = "error_username";
+
+        MemberJoinDTO.MemberJoinRequestDTO request = MemberJoinDTO.MemberJoinRequestDTO.builder()
+                .username(ERROR_USERNAME)
+                .password("Test123!")
+                .name("test")
+                .gender(Gender.FEMALE)
+                .birthDate(LocalDate.of(1, 1, 1))
+                .email("test@naver.com")
+                .phoneNumber("010-1111-1111")
+                .serviceAgreement(true)
+                .privacyAgreement(true)
+                .financialAgreement(true)
+                .advAgreement(true)
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+
+    @Test
+    @DisplayName("이메일 패턴에 불일치 할 시 정해진 예외를 반환한다")
+    void join_fail_email() throws Exception {
+        // given
+        String ERROR_EMAIL = "error_email";
+
+        MemberJoinDTO.MemberJoinRequestDTO request = MemberJoinDTO.MemberJoinRequestDTO.builder()
+                .username("test123")
+                .password("Test123!")
+                .name("test")
+                .gender(Gender.FEMALE)
+                .birthDate(LocalDate.of(1, 1, 1))
+                .email(ERROR_EMAIL)
+                .phoneNumber("010-1111-1111")
+                .serviceAgreement(true)
+                .privacyAgreement(true)
+                .financialAgreement(true)
+                .advAgreement(true)
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+
+    @Test
+    @DisplayName("필수 약관에 모두 동의하지 않으면 정해진 예외를 반환한다")
+    public void join_fail_agreement() throws Exception {
+        //given
+        MemberJoinDTO.MemberJoinRequestDTO request = MemberJoinDTO.MemberJoinRequestDTO.builder()
+                .username("test123")
+                .password("Test123!")
+                .name("test")
+                .gender(Gender.FEMALE)
+                .birthDate(LocalDate.of(1, 1, 1))
+                .email("test@naver.com")
+                .phoneNumber("010-1111-1111")
+                .serviceAgreement(false)
+                .privacyAgreement(true)
+                .financialAgreement(true)
+                .advAgreement(true)
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+
+    @Test
+    @DisplayName("전화번호 패턴에 일치하지 않으면 정해진 예외를 반환한다")
+    public void title() throws Exception {
+        // given
+        String ERROR_PHONE = "error_phone";
+
+        MemberJoinDTO.MemberJoinRequestDTO request = MemberJoinDTO.MemberJoinRequestDTO.builder()
+                .username("test123")
+                .password("Test123!")
+                .name("test")
+                .gender(Gender.FEMALE)
+                .birthDate(LocalDate.of(1, 1, 1))
+                .email("test@naver.com")
+                .phoneNumber(ERROR_PHONE)
+                .serviceAgreement(false)
+                .privacyAgreement(true)
+                .financialAgreement(true)
+                .advAgreement(true)
+                .build();
+
+        // when & then
+        mockMvc.perform(post("/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Issue

- #30 


## Summary

- 자코코 도입 및 MemberController 통합 테스트 구현

## Describe your code

- 커버하지 못한 테스트를 자세하게 조회하는 등의 테스트 커버리지를 위해 자코코를 도입하였습니다.
- 테스트에 대한 경과는 터미널에서 테스트를 포함한 빌드를 실행한 후에 생성되는 report를 보시면 조회 하실 수 있습니다. 다음 회의에서 직접 보여드리며 알려드리겠습니다.
- 현재 도메인, DTO에 대한 테스트 추적은 제외해놓은 상태입니다.
- Service에 대한 커버는 이미 끝났기 때문에 앞으로 Controller 단에서 실행되는 통합테스트와 JPA에 대한 중형테스트를 구현해나가며 부족한 부분을 매꾸도록 하겠습니다.

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
