### PR TITLE
[FEATURE] 메인페이지 API 구현 및 리팩터링 #37

### DIFF
--- a/src/main/java/com/example/bolmalre/concert/converter/ConcertConverter.java
+++ b/src/main/java/com/example/bolmalre/concert/converter/ConcertConverter.java
@@ -4,36 +4,51 @@ import com.example.bolmalre.concert.domain.Concert;
 import com.example.bolmalre.concert.web.dto.ConcertDetailPageDTO;
 import com.example.bolmalre.concert.web.dto.ConcertHomeDTO;
 import com.example.bolmalre.concert.web.dto.ConcertPageDTO;
+import com.example.bolmalre.concert.web.dto.SaveConcertDTO;
+
+import java.util.List;
 
 
 public class ConcertConverter {
 
-    public static ConcertHomeDTO.AdvertisementConcertDTO toAdvertisementConcertDTO(Concert concert, String imageLink) {
+    // 광고 DTO Converter
+    public static ConcertHomeDTO.AdvertisementConcertDTO toAdvertisementConcertDTO(Concert concert) {
 
         return ConcertHomeDTO.AdvertisementConcertDTO.builder()
                 .id(concert.getId())
-                .posterUrl(imageLink)
+                .posterUrl(concert.getPosterUrl())
                 .build();
 
     }
 
-    public static ConcertHomeDTO.RecommendConcertDTO toRecommendConcertDTO(Concert concert, String imageLink) {
+    // 지금 볼래말래 DTO Converter
+    public static ConcertHomeDTO.RecommendConcertDTO toRecommendConcertDTO(
+            Concert concert, List<SaveConcertDTO.ConcertTicketRoundDTO> concertTicketRoundDTOList,
+            ConcertHomeDTO.DateRangeDTO concertRange) {
         return ConcertHomeDTO.RecommendConcertDTO.builder()
                 .id(concert.getId())
-                .posterUrl(imageLink)
+                .posterUrl(concert.getPosterUrl())
+                .concertTicketRoundDTOList(concertTicketRoundDTOList)
                 .concertName(concert.getConcertName())
+                .concertDate(concertRange)  // 콘서트 날짜
                 .build();
     }
 
-    public static ConcertHomeDTO.WeekHotConcertDTO toWeekHotConcertDTO(Concert concert, String imageLink) {
+    // 이번주 가장 인기 있는 티켓 DTO Converter
+    public static ConcertHomeDTO.WeekHotConcertDTO toWeekHotConcertDTO(
+            Concert concert, List<SaveConcertDTO.ConcertTicketRoundDTO> concertTicketRoundDTOList,
+            ConcertHomeDTO.DateRangeDTO concertRange) {
         return ConcertHomeDTO.WeekHotConcertDTO.builder()
                 .id(concert.getId())
-                .posterUrl(imageLink)
+                .posterUrl(concert.getPosterUrl())
+                .concertTicketRoundDTOList(concertTicketRoundDTOList)
                 .concertName(concert.getConcertName())
+                .concertDate(concertRange)  // 콘서트 날짜
                 .concertPlace(concert.getConcertPlace())
                 .build();
     }
 
+    // Concert 페이지 DTO
     public static ConcertPageDTO.ConcertInfoDTO toConcertInfoDTO(Concert concert, String imageLink) {
         return ConcertPageDTO.ConcertInfoDTO.builder()
                 .id(concert.getId())

--- a/src/main/java/com/example/bolmalre/concert/domain/Concert.java
+++ b/src/main/java/com/example/bolmalre/concert/domain/Concert.java
@@ -66,7 +66,6 @@ public class Concert extends BaseEntity {
     @OneToMany(mappedBy = "concert", cascade = CascadeType.ALL)
     private List<ConcertArtist> concertArtists = new ArrayList<>();
 
-    // (ticket_open_dates)₩
     @OneToMany(mappedBy = "concert", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ConcertTicketRound> concertTicketRounds = new ArrayList<>();
 

--- a/src/main/java/com/example/bolmalre/concert/domain/Concert.java
+++ b/src/main/java/com/example/bolmalre/concert/domain/Concert.java
@@ -66,9 +66,6 @@ public class Concert extends BaseEntity {
     @OneToMany(mappedBy = "concert", cascade = CascadeType.ALL)
     private List<ConcertArtist> concertArtists = new ArrayList<>();
 
-    @OneToMany(mappedBy = "concert", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ConcertTicketRound> concertTicketRounds = new ArrayList<>();
-
 
     public void increaseDailyViewCount() {
         this.dailyViewCount++;

--- a/src/main/java/com/example/bolmalre/concert/infrastructure/ConcertPerformanceRoundRepository.java
+++ b/src/main/java/com/example/bolmalre/concert/infrastructure/ConcertPerformanceRoundRepository.java
@@ -1,7 +1,13 @@
 package com.example.bolmalre.concert.infrastructure;
 
+import com.example.bolmalre.concert.domain.Concert;
 import com.example.bolmalre.concert.domain.ConcertPerformanceRound;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ConcertPerformanceRoundRepository extends JpaRepository<ConcertPerformanceRound,Long> {
+
+    List<ConcertPerformanceRound> findAllByConcert(Concert concert);
 }

--- a/src/main/java/com/example/bolmalre/concert/infrastructure/ConcertRepository.java
+++ b/src/main/java/com/example/bolmalre/concert/infrastructure/ConcertRepository.java
@@ -26,7 +26,7 @@ public interface ConcertRepository extends JpaRepository<Concert, Long> {
     Slice<Concert> findWeeklyTopViewedConcerts(Pageable pageable);
 
     @Query("SELECT DISTINCT c FROM Concert c " +
-            "JOIN c.concertTicketRounds ctr " +
+            "LEFT JOIN fetch ConcertTicketRound ctr on c.id = ctr.concert.id " +
             "WHERE ctr.ticketOpenDate BETWEEN :now AND :oneWeekLater")
     List<Concert> findConcertsWithTicketsOpeningInOneWeek(@Param("now") LocalDateTime now,
                                                           @Param("oneWeekLater") LocalDateTime oneWeekLater);

--- a/src/main/java/com/example/bolmalre/concert/infrastructure/ConcertTicketRoundRepository.java
+++ b/src/main/java/com/example/bolmalre/concert/infrastructure/ConcertTicketRoundRepository.java
@@ -1,7 +1,12 @@
 package com.example.bolmalre.concert.infrastructure;
 
+import com.example.bolmalre.concert.domain.Concert;
 import com.example.bolmalre.concert.domain.ConcertTicketRound;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ConcertTicketRoundRepository extends JpaRepository<ConcertTicketRound, Long> {
+
+    Optional<ConcertTicketRound> findByConcert(Concert concert);
 }

--- a/src/main/java/com/example/bolmalre/concert/web/controller/ConcertController.java
+++ b/src/main/java/com/example/bolmalre/concert/web/controller/ConcertController.java
@@ -17,8 +17,8 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/concert")
-@Tag(name = "콘서트 관련 API")
+@RequestMapping("/home")
+@Tag(name = "메인 페이지 조회 API")
 @Builder
 public class ConcertController {
 
@@ -35,15 +35,25 @@ public class ConcertController {
 
     }
 
+    // FIXME (로그인 전후)
     @Operation(summary = "지금 볼래 말래? 조회 API",
             description = "로그인을 안했을 경우에는 ")
-    @GetMapping("/")
-    public ApiResponse<List<ConcertHomeDTO.RecommendConcertDTO>> getRecommendConcert(
-            @RequestParam Long memberId
-    ) {
+    @GetMapping("/recommend")
+    public ApiResponse<List<ConcertHomeDTO.RecommendConcertDTO>> getRecommendConcert()
+    {
 
+        List<ConcertHomeDTO.RecommendConcertDTO> response = concertService.getRecommendConcertInfoBeforeLogin();
 
-        return null;
+        return ApiResponse.onSuccess(response);
 
+    }
+
+    @Operation(summary = "이번주 가장 인기 있는 콘서트")
+    @GetMapping("/hot")
+    public ApiResponse<List<ConcertHomeDTO.WeekHotConcertDTO>> getWeekHotConcert(){
+
+        List<ConcertHomeDTO.WeekHotConcertDTO> response = concertService.getWeekHotConcertInfo();
+
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/bolmalre/concert/web/dto/ConcertHomeDTO.java
+++ b/src/main/java/com/example/bolmalre/concert/web/dto/ConcertHomeDTO.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ConcertHomeDTO {
 
@@ -39,17 +40,15 @@ public class ConcertHomeDTO {
         @Schema(description = "콘서트 포스터 URL")
         private String posterUrl;
 
-        @Schema(description = "1차 티켓오픈, 2차 티켓오픈, 선예매 등 티켓회차")
-        private TicketRound ticketRound;
-
-        @Schema(description = "티켓팅 오픈 날짜+시간")
-        private LocalDateTime ticketOpenDate;
+        @Schema(description = "콘서트 티켓 오픈 일정")
+        private List<SaveConcertDTO.ConcertTicketRoundDTO> concertTicketRoundDTOList;
 
         @Schema(description = "콘서트 이름")
         private String concertName;
 
+        // ConcertPerformanceRound - concertDate (List)
         @Schema(description = "콘서트 공연 일자 (날짜)")
-        private LocalDate concertDate;
+        private DateRangeDTO concertDate;
     }
 
     @NoArgsConstructor
@@ -64,19 +63,31 @@ public class ConcertHomeDTO {
         @Schema(description = "콘서트 포스터 URL")
         private String posterUrl;
 
-        @Schema(description = "1차 티켓오픈, 2차 티켓오픈, 선예매 등 티켓회차")
-        private TicketRound ticketRound;
-
-        @Schema(description = "티켓팅 오픈 날짜+시간")
-        private LocalDateTime ticketOpenDate;
+        @Schema(description = "콘서트 티켓 오픈 일정")
+        private List<SaveConcertDTO.ConcertTicketRoundDTO> concertTicketRoundDTOList;
 
         @Schema(description = "콘서트 이름")
         private String concertName;
 
+        // ConcertPerformanceRound - concertDate (List)
         @Schema(description = "콘서트 공연 일자 (날짜)")
-        private LocalDate concertDate;
+        private DateRangeDTO concertDate;
 
         @Schema(description = "콘서트 장소")
         private String concertPlace;
     }
+
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class DateRangeDTO {
+        @Schema(description = "공연 시작 날짜")
+        private LocalDate startDate;
+        @Schema(description = "공연 마지막 날짜")
+        private LocalDate endDate;
+    }
+
+
 }

--- a/src/main/java/com/example/bolmalre/config/SecurityConfig.java
+++ b/src/main/java/com/example/bolmalre/config/SecurityConfig.java
@@ -105,6 +105,7 @@ public class SecurityConfig {
                 .requestMatchers("phone-numbers/**").permitAll()
                 .requestMatchers("/emails/**").permitAll()
                 .requestMatchers("/concerts/save/**").permitAll()
+                .requestMatchers("/home/**").permitAll()
                 .requestMatchers("/templates/oauth/kakao/callback", "/templates/oauth/naver/callback", "templates/oauth/kakao/front").permitAll() // OAuth 콜백 주소
                 .requestMatchers("/oauth/**").permitAll()
 


### PR DESCRIPTION
## Issue

- [[FEATURE] 메인페이지 API 구현 및 리팩터링 #37  ](https://github.com/bolmal/Back-end/issues/37)


## Summary

- 메인 페이지에 들어가는 세가지 부분 api 구현
- 두번째 지금 볼래말래의 경우에는 로그인 이후에는 추천도 점수에 따른 순서로 보여지지만 추천도 점수를 받지 못하여서 현재 보류
- Concert와 ConcertTicketRound 양방향 매핑을 다시 단방향 매핑으로 수정 후 query에서 fetch join 활용


# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
